### PR TITLE
Fixed typo to make language syntax-error free

### DIFF
--- a/org.metaborg.lang.pascal/trans/statics/static-semantics.nabl2
+++ b/org.metaborg.lang.pascal/trans/statics/static-semantics.nabl2
@@ -45,7 +45,7 @@ rules // run-time library (=> define separately?)
                                   // correct?
                                     
     Op{OR()}   <- s, Op{OR()}   : FunT([BoolT(), BoolT()], BoolT()), 
-    Op{AND()}  <- s, Op{AND()}  : FunT([BoolT(), BoolT()], BoolT()), 
+    Op{AND()}  <- s, Op{AND()}  : FunT([BoolT(), BoolT()], BoolT()).
 
 rules
 


### PR DESCRIPTION
There was a small typo in the static sementics, which prevented the project form compiling
This PR would fix that typo